### PR TITLE
material-ui typography upgrade; removes warnings

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -30,6 +30,9 @@ const styles = theme => ({
   },
   appBar: {
     zIndex: theme.zIndex.drawer + 1
+  },
+  typography: {
+    useNextVariants: true,
   }
 })
 
@@ -69,7 +72,7 @@ class App extends Component {
       <div>
         <AppBar position="static" className={classes.appBar}>
           <Toolbar>
-            <Typography variant="title" color="inherit" className={classes.flex}>
+            <Typography variant="h6" color="inherit" className={classes.flex}>
               {`material-ui-filter (${source.length} entries)`}
             </Typography>
             <div style={{ display: 'flex' }}>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -13,7 +13,9 @@ import { createStore, compose, applyMiddleware } from 'redux'
 import { render } from 'react-dom'
 
 const logger = createLogger({})
-const muiTheme = createMuiTheme()
+const muiTheme = createMuiTheme({typography: {
+  useNextVariants: true,
+}})
 const store = createStore(reducers, {}, compose(applyMiddleware(logger)))
 
 render(

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -217,7 +217,7 @@ class FilterDrawer extends Component {
               <Divider />
 
               <Toolbar>
-                <Typography variant="subheading" color="inherit" className={classes.flex}>
+                <Typography variant="subtitle" color="inherit" className={classes.flex}>
                   {formatMessage ? formatMessage({ id: 'filter' }) : 'Filter'}
                 </Typography>
                 <Tooltip

--- a/src/components/FilterDrawer.js
+++ b/src/components/FilterDrawer.js
@@ -30,6 +30,9 @@ const styles = theme => ({
   },
   drawer: {
     zIndex: theme.zIndex.drawer + 2
+  },
+  typography: {
+    useNextVariants: true,
   }
 })
 


### PR DESCRIPTION
I am trying to remove warning reported on chrome console due to the typography upgrade. Could you include this so i could pull the next version including this change